### PR TITLE
Disable Renovate JavaScript package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["npm", "bun", "yarn"],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- disable Renovate updates for `npm`, `bun`, and `yarn`
- keep JavaScript package version changes manual until the ecosystem issue is settled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified dependency management configuration to disable automatic updates for npm, bun, and yarn ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->